### PR TITLE
Revert realtime back to 2.28.32

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,7 +189,7 @@ services:
   realtime:
     # This container name looks inconsistent but is correct because realtime constructs tenant id by parsing the subdomain
     container_name: realtime-dev.supabase-realtime
-    image: supabase/realtime:v2.30.14
+    image: supabase/realtime:v2.28.32
     depends_on:
       db:
         # Disable this if you are using an external Postgres database


### PR DESCRIPTION
 since newer versions seems to have issues when self-hosted

It might be connected with this:
https://github.com/orgs/supabase/discussions/18228